### PR TITLE
feat: Update AgentClient and sample_agent to use agent_role

### DIFF
--- a/github_broker/infrastructure/agent/client.py
+++ b/github_broker/infrastructure/agent/client.py
@@ -14,7 +14,7 @@ class AgentClient:
     def __init__(
         self,
         agent_id: str,
-        capabilities: list[str],
+        agent_role: str,
         host: str = "localhost",
         port: int | None = None,
     ):
@@ -23,12 +23,12 @@ class AgentClient:
 
         Args:
             agent_id (str): エージェントの一意な識別子。
-            capabilities (List[str]): エージェントの機能リスト。
+            agent_role (str): エージェントのロール。
             host (str): サーバーのホスト名。デフォルトは"localhost"。
             port (Optional[int]): サーバーのポート。デフォルトはAPP_PORT環境変数または8080。
         """
         self.agent_id = agent_id
-        self.capabilities = capabilities
+        self.agent_role = agent_role
         self.host = host
         self.port = port if port is not None else int(os.getenv("BROKER_PORT", 8080))
         self.endpoint = "/request-task"
@@ -42,7 +42,7 @@ class AgentClient:
         Returns:
             Optional[Dict[str, Any]]: 割り当てられたタスク情報、または利用可能なタスクがない場合はNone。
         """
-        payload = {"agent_id": self.agent_id, "capabilities": self.capabilities}
+        payload = {"agent_id": self.agent_id, "agent_role": self.agent_role}
         url = f"http://{self.host}:{self.port}{self.endpoint}"
         try:
             # `requests`ライブラリは、接続プールやタイムアウト管理などを自動で行います。

--- a/sample_agent.py
+++ b/sample_agent.py
@@ -21,29 +21,18 @@ if __name__ == "__main__":
     gemini_log_dir = os.getenv("GEMINI_LOG_DIR", "/app/logs")
     gemini_model = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
 
-    capabilities = [
-        "software-design",
-        "clean-architecture",
-        "tdd",
-        "refactoring",
-        "python",
-        "fastapi",
-        "docker",
-        "github-actions",
-        "technical-writing",
-        "日本語",
-    ]
+    agent_role = os.getenv("AGENT_ROLE", "BACKENDCODER")
     # --------------------------
 
     logging.info(f"エージェント '{agent_id}' を開始します。")
     logging.info(f"サーバー {host}:{port} に接続しています。")
     logging.info(f"ログディレクトリ: {gemini_log_dir}")
-    logging.info(f"機能: {capabilities}")
+    logging.info(f"ロール: {agent_role}")
     print("-" * 30)
 
     # AgentClientとExecutorを初期化
     client = AgentClient(
-        agent_id=agent_id, capabilities=capabilities, host=host, port=port
+        agent_id=agent_id, agent_role=agent_role, host=host, port=port
     )
     executor = GeminiExecutor(log_dir=gemini_log_dir, model=gemini_model)
 

--- a/tests/infrastructure/agent/test_agent_client.py
+++ b/tests/infrastructure/agent/test_agent_client.py
@@ -10,7 +10,7 @@ from github_broker import AgentClient
 @pytest.fixture
 def agent_client():
     """AgentClientのテストインスタンスを提供します。"""
-    return AgentClient(agent_id="test-agent", capabilities=["python"])
+    return AgentClient(agent_id="test-agent", agent_role="BACKENDCODER")
 
 
 @patch("requests.post")
@@ -35,7 +35,7 @@ def test_request_task_success(mock_post, agent_client):
     )
     expected_payload = {
         "agent_id": agent_client.agent_id,
-        "capabilities": agent_client.capabilities,
+        "agent_role": agent_client.agent_role,
     }
     mock_post.assert_called_once_with(
         expected_url, json=expected_payload, headers=agent_client.headers, timeout=30
@@ -101,7 +101,7 @@ def test_agent_client_initialization_with_port():
     """
     特定のポートでAgentClientが初期化されることをテストします。
     """
-    client = AgentClient(agent_id="test", capabilities=[], host="testhost", port=9000)
+    client = AgentClient(agent_id="test", agent_role="", host="testhost", port=9000)
     assert client.port == 9000
 
 
@@ -110,7 +110,7 @@ def test_agent_client_initialization_with_env_var():
     """
     BROKER_PORT環境変数を使用してAgentClientが初期化されることをテストします。
     """
-    client = AgentClient(agent_id="test", capabilities=[])
+    client = AgentClient(agent_id="test", agent_role="")
     assert client.port == 9999
 
 
@@ -119,5 +119,5 @@ def test_agent_client_initialization_default_port(monkeypatch):
     環境変数が設定されていない場合に、AgentClientがデフォルトポートで初期化されることをテストします。
     """
     monkeypatch.delenv("BROKER_PORT", raising=False)
-    client = AgentClient(agent_id="test", capabilities=[])
+    client = AgentClient(agent_id="test", agent_role="")
     assert client.port == 8080


### PR DESCRIPTION
This PR updates `AgentClient` and `sample_agent.py` to be compliant with the latest API specifications, using `agent_role` instead of `capabilities`.

Fixes #170