### PR TITLE
fix(github): Exclude issues with 'needs-review' label from task assignment

### DIFF
--- a/github_broker/infrastructure/github_client.py
+++ b/github_broker/infrastructure/github_client.py
@@ -20,7 +20,7 @@ class GitHubClient:
         リポジトリに存在するすべてのオープンなIssueを取得します。
         """
         try:
-            query = f"repo:{repo_name} is:issue is:open"
+            query = f'repo:{repo_name} is:issue is:open -label:"needs-review"'
             logging.info(f"クエリ: {query} でオープンなIssueを検索中")
             issues = self._client.search_issues(query=query)
             logging.info(f"オープンなIssueが {issues.totalCount} 件見つかりました。")


### PR DESCRIPTION
This pull request resolves #337 by excluding issues with the `needs-review` label from the task assignment query.

- Modified `get_open_issues` in `GitHubClient` to add `-label:"needs-review"` to the search query.
- All tests and pre-commit checks have passed.