### PR TITLE
refactor: TaskServiceの責務をGitHub APIの直接ポーリングに変更

### DIFF
--- a/github_broker/application/task_service.py
+++ b/github_broker/application/task_service.py
@@ -35,16 +35,12 @@ class TaskService:
         """
         assert self.repo_name is not None
         logger.info(f"Completing previous task for agent: {agent_id}")
-        all_issues = self.redis_client.get_all_issues()
-        if not all_issues:
-            logger.info("No issues found in Redis cache.")
+        previous_issues = self.github_client.find_issues_by_labels(
+            repo_name=self.repo_name, labels=["in-progress", agent_id]
+        )
+        if not previous_issues:
+            logger.info("No in-progress issues found for this agent.")
             return
-
-        previous_issues = []
-        for issue in all_issues:
-            labels = [label["name"] for label in issue.get("labels", [])]
-            if "in-progress" in labels and agent_id in labels:
-                previous_issues.append(issue)
 
         for issue in previous_issues:
             logger.info(
@@ -159,6 +155,8 @@ class TaskService:
         """
         self.complete_previous_task(agent_id)
 
+        assert self.repo_name is not None
+
         try:
             wait_seconds = int(
                 os.getenv(
@@ -179,7 +177,7 @@ class TaskService:
 
         while True:
             logger.info(f"Searching for open issues in repository: {self.repo_name}")
-            all_issues = self.redis_client.get_all_issues()
+            all_issues = self.github_client.get_open_issues(self.repo_name)
             if all_issues:
                 candidate_issues = self._find_candidates_by_role(all_issues, agent_role)
                 if candidate_issues:

--- a/github_broker/application/task_service.py
+++ b/github_broker/application/task_service.py
@@ -17,6 +17,8 @@ _DEFAULT_GITHUB_INDEXING_WAIT_SECONDS = 15
 
 
 class TaskService:
+    repo_name: str
+
     def __init__(
         self,
         redis_client: RedisClient,
@@ -24,9 +26,10 @@ class TaskService:
     ):
         self.redis_client = redis_client
         self.github_client = github_client
-        self.repo_name = os.getenv("GITHUB_REPOSITORY")
-        if not self.repo_name:
+        repo_name_str = os.getenv("GITHUB_REPOSITORY")
+        if not repo_name_str:
             raise ValueError("GITHUB_REPOSITORY環境変数が設定されていません。")
+        self.repo_name = repo_name_str
 
     def complete_previous_task(self, agent_id: str):
         """
@@ -154,8 +157,6 @@ class TaskService:
             TaskResponse | None: 見つかったタスクの情報。タイムアウトした場合はNoneを返します。
         """
         self.complete_previous_task(agent_id)
-
-        assert self.repo_name is not None
 
         try:
             wait_seconds = int(

--- a/github_broker/infrastructure/github_client.py
+++ b/github_broker/infrastructure/github_client.py
@@ -34,27 +34,14 @@ class GitHubClient:
     def find_issues_by_labels(self, repo_name: str, labels: list[str]):
         """
         指定されたすべてのラベルを持つIssue（オープンまたはクローズ済み）を検索します。
-        この実装は、検索インデックスの遅延を避けるために、すべてのIssueを取得し手動でフィルタリングします。
         """
         try:
-            repo = self._client.get_repo(repo_name)
-            all_issues = repo.get_issues(state="all")
-            required_labels = set(labels)
-            found_issues = []
-
-            for issue in all_issues:
-                issue_labels = {label.name for label in issue.labels}
-                if required_labels.issubset(issue_labels):
-                    logging.info(
-                        f"Found matching issue #{issue.number} with labels {issue_labels}"
-                    )
-                    found_issues.append(issue)
-
-            if not found_issues:
-                logging.info(f"No issues found with the required labels: {labels}")
-
-            return found_issues
-
+            labels_query = " ".join([f'label:"{label}"' for label in labels])
+            query = f"repo:{repo_name} is:issue {labels_query}"
+            logging.info(f"クエリ: {query} でIssueを検索中")
+            issues = self._client.search_issues(query=query)
+            logging.info(f"{issues.totalCount} 件のIssueが見つかりました。")
+            return list(issues)
         except GithubException as e:
             logging.error(
                 f"An error occurred while searching for issues by labels in repo {repo_name}: {e}"

--- a/tests/application/test_task_service.py
+++ b/tests/application/test_task_service.py
@@ -126,11 +126,7 @@ def test_request_task_finds_task_after_polling(
         labels=["BACKENDCODER"],
     )
     # 最初の呼び出しではタスクなし、2回目以降は見つかるように設定
-    mock_github_client.get_open_issues.side_effect = (
-        lambda repo_name: [issue]
-        if mock_github_client.get_open_issues.call_count > 1
-        else []
-    )
+    mock_github_client.get_open_issues.side_effect = [[], [issue]]
     mock_redis_client.acquire_lock.return_value = True
     timeout = 10
     mock_time.side_effect = [0, 5, 11]  # 1回ポーリングして見つかる


### PR DESCRIPTION
Issue #408 の対応プルリクエストです。

## 目的 (Goal)
`TaskService` が、ローカルのRedisキャッシュではなく、GitHub APIから直接Issue情報を取得するように変更します。

## 完了条件 (Acceptance Criteria)
- `TaskService` 内の `request_task` メソッドが、`redis_client.get_all_issues()` の代わりに `github_client` を利用して、リポジトリから直接Issueをフェッチするように変更されていること。
- `TaskService` 内の `complete_previous_task` メソッドも同様に、RedisキャッシュではなくGitHub APIから "in-progress" 状態のIssueを検索するように変更されていること。
- ロングポーリングのロジックは維持しつつ、タイムアウト時に再試行するのはRedisへのクエリではなく、GitHub APIへのクエリであること。
- 既存の `redis_client` への依存のうち、Issueキャッシュに関連する部分は削除されていること（ロック機能など、他の目的での利用は維持してよい）。
- 関連する単体テスト (`tests/application/test_task_service.py`) が、`redis_client` のモックではなく `github_client` のモックを使用するように更新されていること。