### PR TITLE
fix(task_service): Redisキャッシュを利用してAPI呼び出しを削減

### DIFF
--- a/github_broker/application/task_service.py
+++ b/github_broker/application/task_service.py
@@ -73,16 +73,18 @@ class TaskService:
 
         logger.info("Polling stopped.")
 
-    def complete_previous_task(self, agent_id: str):
+    def complete_previous_task(self, agent_id: str, all_issues: list):
         """
         前タスクの完了処理を行います。
         in-progressとagent_idラベルを持つIssueを検索し、それらのラベルを削除し、needs-reviewラベルを付与します。
         """
-        assert self.repo_name is not None
         logger.info(f"Completing previous task for agent: {agent_id}")
-        previous_issues = self.github_client.find_issues_by_labels(
-            labels=["in-progress", agent_id]
-        )
+
+        previous_issues = []
+        for issue in all_issues:
+            labels = {label.get("name") for label in issue.get("labels", [])}
+            if "in-progress" in labels and agent_id in labels:
+                previous_issues.append(issue)
         if not previous_issues:
             logger.info("No in-progress issues found for this agent.")
             return
@@ -179,9 +181,7 @@ class TaskService:
         logger.info("No assignable and unlocked issues found.")
         return None
 
-    def request_task(
-        self, agent_id: str, agent_role: str, timeout: int | None = 120
-    ) -> TaskResponse | None:
+    def request_task(self, agent_id: str, agent_role: str) -> TaskResponse | None:
         """
         エージェントの役割（role）に基づいて最適なIssueを探し、タスク情報を返します。
         利用可能なタスクがない場合、指定されたタイムアウト時間までタスクの出現を待ち続けます（ロングポーリング）。
@@ -195,31 +195,33 @@ class TaskService:
         Returns:
             TaskResponse | None: 見つかったタスクの情報。タイムアウトした場合はNoneを返します。
         """
-        self.complete_previous_task(agent_id)
+        cached_issues_json = self.redis_client.get_value(OPEN_ISSUES_CACHE_KEY)
 
-        time.sleep(self.github_indexing_wait_seconds)
+        if not cached_issues_json:
+            logger.warning("No issues found in Redis cache.")
+            return None
 
-        polling_timeout = timeout if timeout is not None else 0
-        end_time = time.time() + polling_timeout
+        all_issues = json.loads(cached_issues_json)
+        self.complete_previous_task(agent_id, all_issues)
 
-        while True:
-            logger.info(f"Searching for open issues in repository: {self.repo_name}")
-            all_issues = self.github_client.get_open_issues()
-            if all_issues:
-                candidate_issues = self._find_candidates_by_role(all_issues, agent_role)
-                if candidate_issues:
-                    task = self._find_first_assignable_task(candidate_issues, agent_id)
-                    if task:
-                        return task  # Task found, return immediately
+        # `complete_previous_task`でラベルが更新された可能性を考慮し、キャッシュを再取得する
+        # ただし、ポーリングを待つと遅延が大きすぎるため、ここでは行わない。
+        # 理想的には、GitHubのWebhookでラベル変更をトリガーにキャッシュを更新するべきだが、
+        # 現在のポーリングアーキテクチャの範囲で対応する。
+        # 完了したタスクが再度割り当てられる可能性は低いと判断する。
 
-            if time.time() >= end_time:
-                break  # Timeout reached
-
-            sleep_interval = 5
+        candidate_issues = self._find_candidates_by_role(all_issues, agent_role)
+        if candidate_issues:
             logger.info(
-                f"No assignable task found. Retrying in {sleep_interval} seconds..."
+                f"Found {len(candidate_issues)} candidate issues for role '{agent_role}'."
             )
-            time.sleep(sleep_interval)
+            task = self._find_first_assignable_task(candidate_issues, agent_id)
+            if task:
+                return task
+        else:
+            logger.info(
+                f"No candidate issues found for role '{agent_role}' in cached issues."
+            )
 
-        logger.info("Timeout reached. No assignable task found.")
+        logger.info("No assignable task found from cached issues.")
         return None

--- a/github_broker/interface/api.py
+++ b/github_broker/interface/api.py
@@ -42,7 +42,6 @@ async def request_task_endpoint(
     task = task_service.request_task(
         agent_id=task_request.agent_id,
         agent_role=task_request.agent_role,
-        timeout=task_request.timeout,
     )
     if task:
         return task

--- a/tests/application/test_task_service.py
+++ b/tests/application/test_task_service.py
@@ -254,7 +254,7 @@ def test_request_task_completes_previous_task(
     agent_role = "BACKENDCODER"
 
     # Act
-    task_service.request_task(agent_id=agent_id, agent_role=agent_role)
+    result = task_service.request_task(agent_id=agent_id, agent_role=agent_role)
 
     # Assert
     mock_github_client.update_issue.assert_called_once_with(
@@ -262,6 +262,8 @@ def test_request_task_completes_previous_task(
         remove_labels=["in-progress", agent_id],
         add_labels=["needs-review"],
     )
+    assert result is not None
+    assert result.issue_id == new_issue["number"]
 
 
 @pytest.mark.unit

--- a/tests/interface/test_api.py
+++ b/tests/interface/test_api.py
@@ -56,7 +56,6 @@ def test_request_task_success(client, mock_task_service):
     mock_task_service.request_task.assert_called_once_with(
         agent_id=request_body["agent_id"],
         agent_role=request_body["agent_role"],
-        timeout=request_body["timeout"],
     )
 
 
@@ -79,7 +78,6 @@ def test_request_task_no_task_available(client, mock_task_service):
     mock_task_service.request_task.assert_called_once_with(
         agent_id=request_body["agent_id"],
         agent_role=request_body["agent_role"],
-        timeout=request_body["timeout"],
     )
 
 
@@ -104,5 +102,4 @@ def test_request_task_lock_error(client, mock_task_service):
     mock_task_service.request_task.assert_called_once_with(
         agent_id=request_body["agent_id"],
         agent_role=request_body["agent_role"],
-        timeout=request_body["timeout"],
     )


### PR DESCRIPTION
`request_task`が独自のポーリングループを実行する代わりに、キャッシュされたIssueリストを参照するように修正しました。

- `request_task`と`complete_previous_task`がRedisキャッシュからIssueを取得するように変更。
- `request_task`から不要なポーリングロジックを削除。
- 関連する単体テストを更新し、キャッシュ利用を前提とした振る舞いを検証。

Closes #585