### PR TITLE
fix: Remove dead link from docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@
 *   [DIコンテナ](./architecture/di-container.md)
 *   [運用・デプロイ要件](./architecture/operational-requirements.md)
 *   [Redisスキーマ](./architecture/redis-schema.md)
-*   [Webhookアーキテクチャ](./architecture/webhook-based-architecture.md)
+
 
 ## 2. 開発者向けガイド
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,6 @@
 *   [DIコンテナ](./architecture/di-container.md)
 *   [運用・デプロイ要件](./architecture/operational-requirements.md)
 *   [Redisスキーマ](./architecture/redis-schema.md)
-
-
 ## 2. 開発者向けガイド
 
 開発を始めるために必要な手順や、知っておくべきワークフローについて説明します。


### PR DESCRIPTION
## 背景 (Background)
`ADR-003`に基づき、プロジェクトはWebhookベースのアーキテクチャからポーリング方式に移行しました。
それに伴い、古い設計書である`docs/architecture/webhook-based-architecture.md`は削除されましたが、ドキュメントポータルである`docs/index.md`に、そのファイルへのリンクが残存しています。

## 目的 (Goal)
ドキュメントの正確性と信頼性を維持するため、このデッドリンクを削除します。

## 完了条件 (Acceptance Criteria)
- [x] `docs/index.md`ファイルから、`*   [Webhookアーキテクチャ](./architecture/webhook-based-architecture.md)` の行が削除されていること。
- [x] 変更がコミットされ、Pull Requestが作成されていること。

Closes #635