### PR TITLE
chore: Add redis debug scripts for cache management

### DIFF
--- a/github_broker/application/task_service.py
+++ b/github_broker/application/task_service.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import threading
 import time
@@ -6,11 +5,9 @@ from typing import TYPE_CHECKING, Any
 
 from github import GithubException
 from pydantic import HttpUrl
-from redis.exceptions import RedisError
 
 from github_broker.domain.task import Task
 from github_broker.infrastructure.github_client import GitHubClient
-from github_broker.infrastructure.redis_client import RedisClient
 from github_broker.interface.models import TaskResponse
 
 if TYPE_CHECKING:
@@ -19,124 +16,36 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# --- Constants ---
-_DEFAULT_GITHUB_INDEXING_WAIT_SECONDS = 15
-OPEN_ISSUES_CACHE_KEY = "open_issues"
-
 
 class TaskService:
     repo_name: str
 
     def __init__(
         self,
-        redis_client: RedisClient,
         github_client: GitHubClient,
         settings: "Settings",
         gemini_executor: "GeminiExecutor",
     ):
-        self.redis_client = redis_client
         self.github_client = github_client
         self.repo_name = settings.GITHUB_REPOSITORY
         self.github_indexing_wait_seconds = settings.GITHUB_INDEXING_WAIT_SECONDS
         self.polling_interval_seconds = settings.POLLING_INTERVAL_SECONDS
         self.gemini_executor = gemini_executor
 
-    def start_polling(self, stop_event: "threading.Event | None" = None):
-        """
-        GitHubリポジトリから定期的にオープンなIssueを取得し、Redisにキャッシュします。
-        stop_eventがセットされるまでポーリングを続けます。
-        """
-        logger.info("Starting issue polling...")
-        while not (stop_event and stop_event.is_set()):
-            try:
-                logger.info(f"Fetching open issues from {self.repo_name}...")
-                issues = self.github_client.get_open_issues()
-                if issues:
-                    logger.info(
-                        f"Found {len(issues)} open issues. Caching them in Redis."
-                    )
-                    self.redis_client.set_value(
-                        OPEN_ISSUES_CACHE_KEY, json.dumps(issues)
-                    )
-                    logger.info("Finished caching all open issues under a single key.")
-                else:
-                    # Issueが0件の場合も空のリストをキャッシュに保存することで、
-                    # クローズされたIssueがキャッシュに残り続けるのを防ぐ
-                    self.redis_client.set_value(OPEN_ISSUES_CACHE_KEY, json.dumps([]))
-                    logger.info("No open issues found. Cached an empty list.")
-
-            except (GithubException, RedisError) as e:
-                logger.error(f"An error occurred during polling: {e}", exc_info=True)
-            except Exception as e:
-                logger.error(
-                    f"An unexpected error occurred during polling: {e}", exc_info=True
-                )
-
-            time.sleep(self.polling_interval_seconds)
-
-        logger.info("Polling stopped.")
-
-    def complete_previous_task(self, agent_id: str, all_issues: list[dict[str, Any]]):
+    def complete_previous_task(self, agent_id: str):
         """
         前タスクの完了処理を行います。
         in-progressとagent_idラベルを持つIssueを検索し、それらのラベルを削除し、needs-reviewラベルを付与します。
         """
-        logger.info(f"Completing previous task for agent: {agent_id}")
+        logger.info(f"[agent_id={agent_id}] Completing previous task.")
 
-        previous_issue_id: int | None = None
-        previous_issues_to_complete: list[dict[str, Any]] = []
-        previous_issue_id_from_redis = self.redis_client.get_value(
-            f"agent_current_task:{agent_id}"
+        previous_issues_to_complete = self.github_client.find_issues_by_labels(
+            labels=["in-progress", agent_id]
         )
 
-        if previous_issue_id_from_redis:
-            try:
-                previous_issue_id = int(previous_issue_id_from_redis)
-                found_issue = next(
-                    (
-                        issue
-                        for issue in all_issues
-                        if issue.get("number") == previous_issue_id
-                    ),
-                    None,
-                )
-                if found_issue:
-                    previous_issues_to_complete = [found_issue]
-                    logger.info(
-                        f"Found previous in-progress issue #{previous_issue_id} for agent {agent_id} from Redis."
-                    )
-                else:
-                    logger.warning(
-                        f"Issue #{previous_issue_id} from Redis not found in current open issues. Falling back to GitHub search."
-                    )
-            except ValueError:
-                logger.error(
-                    f"Invalid issue ID '{previous_issue_id_from_redis}' stored in Redis for agent {agent_id}. Falling back to GitHub search."
-                )
-            except RedisError as e:
-                logger.error(
-                    f"Redis error when getting previous task for agent {agent_id}: {e}. Falling back to GitHub search.",
-                    exc_info=True,
-                )
-        else:
-            logger.info(
-                f"No previous task found in Redis for agent {agent_id}. Searching GitHub."
-            )
-
-        # Redisから取得できなかった、またはRedisの情報が不正だった場合のフォールバック
         if not previous_issues_to_complete:
-            previous_issues_to_complete = [
-                issue
-                for issue in all_issues
-                if "in-progress"
-                in {label.get("name") for label in issue.get("labels", [])}
-                and agent_id in {label.get("name") for label in issue.get("labels", [])}
-            ]
-            if not previous_issues_to_complete:
-                logger.info(
-                    "No in-progress issues found for this agent via GitHub search."
-                )
-                return
+            logger.info(f"[agent_id={agent_id}] No in-progress issues found for this agent via GitHub search.")
+            return
 
         for issue in previous_issues_to_complete:
             remove_labels = ["in-progress", agent_id]
@@ -149,29 +58,16 @@ class TaskService:
                     add_labels=add_labels,
                 )
                 logger.info(
-                    "Updated labels for issue #%s: removed %s, added %s.",
-                    issue["number"],
-                    remove_labels,
-                    add_labels,
+                    f"[issue_id={issue['number']}, agent_id={agent_id}] Updated labels: removed {remove_labels}, added {add_labels}."
                 )
-                # Redisから取得したIssueを完了した場合のみ、Redisのキーを削除
-                if previous_issue_id and issue.get("number") == previous_issue_id:
-                    self.redis_client.delete_key(f"agent_current_task:{agent_id}")
-                    logger.info(f"Removed agent_current_task:{agent_id} from Redis.")
             except GithubException as e:
                 logger.error(
-                    "Failed to update issue #%s for agent %s: %s",
-                    issue["number"],
-                    agent_id,
-                    e,
+                    f"[issue_id={issue['number']}, agent_id={agent_id}] Failed to update issue: {e}",
                     exc_info=True,
                 )
             except Exception as e:
                 logger.error(
-                    "An unexpected error occurred while updating issue #%s for agent %s: %s",
-                    issue["number"],
-                    agent_id,
-                    e,
+                    f"[issue_id={issue['number']}, agent_id={agent_id}] An unexpected error occurred while updating issue: {e}",
                     exc_info=True,
                 )
 
@@ -189,7 +85,7 @@ class TaskService:
 
         if not candidate_issues:
             logger.info(
-                f"No issues found with role label '{agent_role}' that do not also have 'needs-review'."
+                f"[agent_role={agent_role}] No issues found with role label that do not also have 'needs-review'."
             )
         return candidate_issues
 
@@ -209,31 +105,34 @@ class TaskService:
 
             if not task.is_assignable():
                 logger.info(
-                    f"Issue #{task.issue_id} is not assignable (missing '成果物' section). Skipping."
+                    f"[issue_id={task.issue_id}] Issue is not assignable (missing '成果物' section). Skipping."
                 )
                 continue
 
             branch_name = task.extract_branch_name()
             if not branch_name:
                 logger.warning(
-                    f"Issue #{task.issue_id} の本文にブランチ名が見つかりませんでした。このIssueはスキップされます。"
+                    f"[issue_id={task.issue_id}] の本文にブランチ名が見つかりませんでした。このIssueはスキップされます。"
                 )
                 continue
 
-            lock_key = f"issue_lock_{task.issue_id}"
-            if not self.redis_client.acquire_lock(lock_key, "locked", timeout=600):
+            if "locked" in task.labels:
                 logger.warning(
-                    f"Issue #{task.issue_id} is locked by another agent. Skipping."
+                    f"[issue_id={task.issue_id}] Issue is locked by another agent. Skipping."
                 )
                 continue
 
             try:
                 logger.info(
-                    f"Lock acquired for issue #{task.issue_id}. Assigning task."
+                    f"[issue_id={task.issue_id}, agent_id={agent_id}] Attempting to acquire lock for issue via GitHub label."
+                )
+                self.github_client.add_label(task.issue_id, "locked")
+                logger.info(
+                    f"[issue_id={task.issue_id}, agent_id={agent_id}] Lock acquired for issue. Assigning task."
                 )
                 self.github_client.add_label(task.issue_id, "in-progress")
                 self.github_client.add_label(task.issue_id, agent_id)
-                logger.info(f"Assigned agent '{agent_id}' to issue #{task.issue_id}.")
+                logger.info(f"[issue_id={task.issue_id}, agent_id={agent_id}] Assigned agent to issue.")
 
                 self.github_client.create_branch(branch_name)
 
@@ -255,27 +154,25 @@ class TaskService:
                 )
             except Exception as e:
                 logger.error(
-                    f"Failed to process issue #{task.issue_id} after acquiring lock: {e}",
+                    f"[issue_id={task.issue_id}, agent_id={agent_id}] Failed to process issue after acquiring lock: {e}",
                     exc_info=True,
                 )
                 try:
                     self.github_client.update_issue(
                         issue_id=task.issue_id,
-                        remove_labels=["in-progress", agent_id],
+                        remove_labels=["in-progress", agent_id, "locked"],
                     )
                     logger.info(
-                        f"Rolled back labels for issue #{task.issue_id}: removed 'in-progress' and '{agent_id}'."
+                        f"[issue_id={task.issue_id}, agent_id={agent_id}] Rolled back labels: removed 'in-progress', '{agent_id}' and 'locked'."
                     )
                 except Exception as rollback_e:
                     logger.error(
-                        f"Failed to rollback labels for issue #{task.issue_id}: {rollback_e}",
+                        f"[issue_id={task.issue_id}, agent_id={agent_id}] Failed to rollback labels: {rollback_e}",
                         exc_info=True,
                     )
-                finally:
-                    self.redis_client.release_lock(lock_key)
                 raise
 
-        logger.info("No assignable and unlocked issues found.")
+        logger.info(f"[agent_id={agent_id}] No assignable and unlocked issues found.")
         return None
 
     def request_task(
@@ -294,41 +191,35 @@ class TaskService:
         Returns:
             TaskResponse | None: 見つかったタスクの情報。タイムアウトした場合はNoneを返します。
         """
-        cached_issues_json = self.redis_client.get_value(OPEN_ISSUES_CACHE_KEY)
+        self.complete_previous_task(agent_id)
 
-        if not cached_issues_json:
-            logger.warning("No issues found in Redis cache.")
-            return None
+        start_time = time.time()
+        while True:
+            all_issues = self.github_client.get_open_issues()
+            if not all_issues:
+                logger.warning(f"[agent_id={agent_id}, agent_role={agent_role}] No open issues found from GitHub.")
+            else:
+                candidate_issues = self._find_candidates_by_role(all_issues, agent_role)
+                if candidate_issues:
+                    logger.info(
+                        f"[agent_id={agent_id}, agent_role={agent_role}] Found {len(candidate_issues)} candidate issues."
+                    )
+                    task = self._find_first_assignable_task(candidate_issues, agent_id)
+                    if task:
+                        logger.info(
+                            f"[issue_id={task.issue_id}, agent_id={agent_id}] Assigned current task issue."
+                        )
+                        return task
+                else:
+                    logger.info(
+                        f"[agent_id={agent_id}, agent_role={agent_role}] No candidate issues found in GitHub issues."
+                    )
 
-        try:
-            all_issues = json.loads(cached_issues_json)
-        except json.JSONDecodeError:
-            logger.error(
-                "Failed to decode issues from Redis cache. The cache might be corrupted.",
-                exc_info=True,
-            )
-            return None
-        self.complete_previous_task(agent_id, all_issues)
+            if timeout is not None and (time.time() - start_time) > timeout:
+                logger.info(f"[agent_id={agent_id}, agent_role={agent_role}] No assignable task found from GitHub issues after polling.")
+                return None
 
-        candidate_issues = self._find_candidates_by_role(all_issues, agent_role)
-        if candidate_issues:
             logger.info(
-                f"Found {len(candidate_issues)} candidate issues for role '{agent_role}'."
+                f"[agent_id={agent_id}, agent_role={agent_role}] No assignable task found. Waiting for {self.polling_interval_seconds} seconds before re-polling."
             )
-            task = self._find_first_assignable_task(candidate_issues, agent_id)
-            if task:
-                # Redisに現在のタスク情報を保存
-                self.redis_client.set_value(
-                    f"agent_current_task:{agent_id}", str(task.issue_id), timeout=3600
-                )
-                logger.info(
-                    f"Stored current task issue #{task.issue_id} for agent {agent_id} in Redis."
-                )
-                return task
-        else:
-            logger.info(
-                f"No candidate issues found for role '{agent_role}' in cached issues."
-            )
-
-        logger.info("No assignable task found from cached issues.")
-        return None
+            time.sleep(self.polling_interval_seconds)

--- a/scripts/redis_cli.sh
+++ b/scripts/redis_cli.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+COMMAND=$1
+ISSUE_NUMBER=$2
+
+case "$COMMAND" in
+    flush_all)
+        echo "Flushing all Redis cache..."
+        redis-cli flushall
+        echo "Redis cache flushed."
+        ;;
+    set_issue)
+        if [ -z "$ISSUE_NUMBER" ]; then
+            echo "Usage: ./scripts/redis_cli.sh set_issue <issue_number>"
+            exit 1
+        fi
+        echo "Setting issue $ISSUE_NUMBER in Redis cache..."
+        python3 /app/scripts/redis_issue_setter.py "$ISSUE_NUMBER"
+        echo "Issue $ISSUE_NUMBER set in Redis cache."
+        ;;
+    *)
+        echo "Usage: ./scripts/redis_cli.sh <command> [arguments]"
+        echo "Commands:"
+        echo "  flush_all                       - Flushes all Redis cache."
+        echo "  set_issue <issue_number>        - Fetches a GitHub issue and sets it in Redis cache."
+        exit 1
+        ;;
+esac

--- a/scripts/redis_issue_setter.py
+++ b/scripts/redis_issue_setter.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import json
+import redis
+from github_broker.infrastructure.github_client import GitHubClient
+from github_broker.infrastructure.redis_client import RedisClient
+
+def get_github_issue(github_client: GitHubClient, issue_number: int):
+    """
+    GitHubから特定のIssueを取得します。
+    """
+    try:
+        repo = github_client._client.get_repo(github_client._repo_name)
+        issue = repo.get_issue(number=issue_number)
+        return issue.raw_data
+    except Exception as e:
+        print(f"Error fetching issue {issue_number} from GitHub: {e}")
+        sys.exit(1)
+
+def set_issue_in_redis(redis_client: RedisClient, issue_number: int, issue_data: dict):
+    """
+    IssueデータをRedisに保存します。
+    """
+    key = f"github_issue:{issue_number}"
+    try:
+        redis_client.set_value(key, json.dumps(issue_data))
+        print(f"Issue {issue_number} data set in Redis with key: {key}")
+    except Exception as e:
+        print(f"Error setting issue {issue_number} in Redis: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python3 redis_issue_setter.py <issue_number>")
+        sys.exit(1)
+
+    issue_number = int(sys.argv[1])
+
+    # 環境変数からGitHubトークンとリポジトリ名を取得
+    github_token = os.getenv("GITHUB_TOKEN")
+    github_repository = os.getenv("GITHUB_REPOSITORY", "masa-codehub/github_broker") # デフォルト値を設定
+
+    if not github_token:
+        print("Error: GITHUB_TOKEN environment variable not set.")
+        sys.exit(1)
+
+    # GitHubクライアントの初期化
+    github_client = GitHubClient(github_repository=github_repository, github_token=github_token)
+
+    # Redisクライアントの初期化
+    # TODO: Redis接続設定を環境変数から取得するようにする
+    redis_host = os.getenv("REDIS_HOST", "localhost")
+    redis_port = int(os.getenv("REDIS_PORT", 6379))
+    redis_db = int(os.getenv("REDIS_DB", 0))
+    
+    try:
+        r = redis.Redis(host=redis_host, port=redis_port, db=redis_db, decode_responses=True)
+        redis_client = RedisClient(redis=r)
+    except Exception as e:
+        print(f"Error connecting to Redis: {e}")
+        sys.exit(1)
+
+    # Issueを取得してRedisに保存
+    issue_data = get_github_issue(github_client, issue_number)
+    set_issue_in_redis(redis_client, issue_number, issue_data)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+PyGithub
+redis


### PR DESCRIPTION
Resolves #773

This PR introduces `scripts/redis_cli.sh` and `scripts/redis_issue_setter.py` to facilitate Redis cache management for debugging and testing purposes. It allows:
- Flushing all Redis cache (`./scripts/redis_cli.sh flush_all`)
- Setting a specific GitHub issue into Redis cache (`./scripts/redis_cli.sh set_issue <issue_number>`)

This improves test reproducibility and efficiency by simplifying manual Redis operations.