### PR TITLE
fix: Remove faulty prompt execution logic from AgentClient

### DIFF
--- a/github_broker/infrastructure/agent/client.py
+++ b/github_broker/infrastructure/agent/client.py
@@ -1,13 +1,9 @@
 import json
 import logging
 import os
-import shlex
-import subprocess
 from typing import Any
 
 import requests
-
-from github_broker.application.exceptions import PromptExecutionError
 
 
 class AgentClient:
@@ -71,39 +67,6 @@ class AgentClient:
             logging.info("New task assigned:")
             logging.info(json.dumps(task, indent=2, ensure_ascii=False))
 
-            if "prompt" in task and task["prompt"]:
-                # Define an allowlist of permitted commands
-                allowed_commands = [
-                    "echo",
-                    "ls",
-                    "pwd",
-                    # Add other safe commands as needed
-                ]
-                try:
-                    prompt_args = shlex.split(task["prompt"])
-                    if prompt_args and prompt_args[0] in allowed_commands:
-                        logging.info(f"Executing prompt: {task['prompt']}")
-                        subprocess.run(
-                            prompt_args,
-                            check=True,
-                            text=True,
-                            capture_output=True,
-                            timeout=timeout,
-                        )
-                        logging.info("Prompt executed successfully.")
-                    else:
-                        logging.error(
-                            f"Prompt '{task['prompt']}' is not in the allowlist and will not be executed."
-                        )
-                        raise PromptExecutionError(
-                            f"Prompt '{task['prompt']}' is not allowed."
-                        )
-                except subprocess.CalledProcessError as e:
-                    error_message = (
-                        f"Prompt execution failed. {e}. Stderr: {e.stderr.strip()}"
-                    )
-                    logging.error(error_message)
-                    raise PromptExecutionError(error_message) from e
             return task
 
         except requests.exceptions.RequestException as e:


### PR DESCRIPTION
Closes #961

AgentClient.request_task() メソッドから、自然言語のプロンプトをシェルコマンドとして誤って実行しようとするロジックを削除しました。
これにより、AgentClient はタスク情報を取得し、タスク辞書を返すだけのシンプルな責務になります。
関連するテストも更新しました。