### PR TITLE
chore: remove GITHUB_WEBHOOK_SECRET remnants

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,6 @@
     -   `github_token`: ご自身のGitHub Personal Access Tokenを記述します。
     -   `gemini_api_key`: ご自身のGemini APIキーを記述します。
 
-
     **（注意）`secrets`ディレクトリとその中のファイルは、Gitの追跡対象外（`.gitignore`に記載済み）です。**
 
 ### 3. コンテナのビルドと実行

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@
 2.  `secrets`ディレクトリ内に、以下のファイル名でそれぞれの機密情報を記述したファイルを作成します。
     -   `github_token`: ご自身のGitHub Personal Access Tokenを記述します。
     -   `gemini_api_key`: ご自身のGemini APIキーを記述します。
-    -   `github_webhook_secret`: GitHub Webhook用に設定したシークレットキーを記述します。
+
 
     **（注意）`secrets`ディレクトリとその中のファイルは、Gitの追跡対象外（`.gitignore`に記載済み）です。**
 

--- a/docs/adr/002-settings-management-with-pydantic.md
+++ b/docs/adr/002-settings-management-with-pydantic.md
@@ -39,7 +39,7 @@ class Settings(BaseSettings):
     # 機密情報 (Docker Secretsから読み込む)
     GITHUB_TOKEN: str
     GEMINI_API_KEY: str
-    GITHUB_WEBHOOK_SECRET: str
+
 
     # 一般的な設定 (環境変数から読み込む)
     BROKER_PORT: int = 8000

--- a/docs/adr/002-settings-management-with-pydantic.md
+++ b/docs/adr/002-settings-management-with-pydantic.md
@@ -40,7 +40,6 @@ class Settings(BaseSettings):
     GITHUB_TOKEN: str
     GEMINI_API_KEY: str
 
-
     # 一般的な設定 (環境変数から読み込む)
     BROKER_PORT: int = 8000
     GITHUB_REPOSITORY: str

--- a/docs/adr/003-polling-only-architecture.md
+++ b/docs/adr/003-polling-only-architecture.md
@@ -25,4 +25,4 @@ Accepted
 - **`WebhookService` の廃止:** `github_broker/application/webhook_service.py` および関連するインターフェース（`api.py`内のエンドポイントなど）は、今後のリファクタリング作業で完全に削除されます。
 - **`TaskService` の責務変更:** `TaskService` は、GitHub APIを定期的にポーリングしてIssue情報をローカルキャッシュ（Redis）に同期する責務を担うように変更されます。このポーリング処理は、独立したバックグラウンドプロセスとして起動されることを想定しています。
 - **`docs/architecture/webhook-based-architecture.md` の廃止:** このアーキテクチャドキュメントは現状と一致しなくなるため、**廃止 (Deprecated)** されます。今後のアーキテクチャに関する参照は、このADRおよび将来作成されるポーリング方式の設計ドキュメントを参照してください。
-- **設定ファイルの変更:** Webhookに関連する環境変数（`GITHUB_WEBHOOK_SECRET`など）は不要となります。
+

--- a/docs/adr/003-polling-only-architecture.md
+++ b/docs/adr/003-polling-only-architecture.md
@@ -25,4 +25,3 @@ Accepted
 - **`WebhookService` の廃止:** `github_broker/application/webhook_service.py` および関連するインターフェース（`api.py`内のエンドポイントなど）は、今後のリファクタリング作業で完全に削除されます。
 - **`TaskService` の責務変更:** `TaskService` は、GitHub APIを定期的にポーリングしてIssue情報をローカルキャッシュ（Redis）に同期する責務を担うように変更されます。このポーリング処理は、独立したバックグラウンドプロセスとして起動されることを想定しています。
 - **`docs/architecture/webhook-based-architecture.md` の廃止:** このアーキテクチャドキュメントは現状と一致しなくなるため、**廃止 (Deprecated)** されます。今後のアーキテクチャに関する参照は、このADRおよび将来作成されるポーリング方式の設計ドキュメントを参照してください。
-

--- a/tests/infrastructure/test_di_container.py
+++ b/tests/infrastructure/test_di_container.py
@@ -25,7 +25,6 @@ def test_di_container_resolves_task_service_instance():
         "GITHUB_TOKEN": "fake-token",
         "GEMINI_API_KEY": "fake-gemini-key",
         "GITHUB_INDEXING_WAIT_SECONDS": "10",
-
         "REDIS_HOST": "localhost",
         "REDIS_PORT": "6379",
         "REDIS_DB": "0",

--- a/tests/infrastructure/test_di_container.py
+++ b/tests/infrastructure/test_di_container.py
@@ -25,7 +25,7 @@ def test_di_container_resolves_task_service_instance():
         "GITHUB_TOKEN": "fake-token",
         "GEMINI_API_KEY": "fake-gemini-key",
         "GITHUB_INDEXING_WAIT_SECONDS": "10",
-        "GITHUB_WEBHOOK_SECRET": "fake-secret-for-testing",
+
         "REDIS_HOST": "localhost",
         "REDIS_PORT": "6379",
         "REDIS_DB": "0",


### PR DESCRIPTION
## 1. 目的とゴール (Purpose & Goal)
- **解決したいIssue:** #997
- **この作業の目的:** 不要となった `GITHUB_WEBHOOK_SECRET` に関する記述をすべて削除する。
- **ゴール(完了条件):** 
  - `CONTRIBUTING.md` から `github_webhook_secret` に関する記述が削除されていること。
  - `tests/infrastructure/test_di_container.py` のテストデータから `GITHUB_WEBHOOK_SECRET` が削除されていること。
  - プロジェクト全体を "GITHUB_WEBHOOK_SECRET" で検索し、他の残存箇所があればそれらも削除されていること。

## 2. 実施内容 (Implementation Details)
### 設計判断と決定事項
- ADR 003によりWebhook機能は廃止され、`GITHUB_WEBHOOK_SECRET` 環境変数は不要となったため、関連する記述を削除しました。

### 具体的な作業ログと成果物
- **作業ブランチ:** `chore/remove-webhook-secret-remnants`
- **主要な変更ファイル:**
  - `CONTRIBUTING.md`
  - `tests/infrastructure/test_di_container.py`
  - `docs/adr/003-polling-only-architecture.md`
  - `docs/adr/002-settings-management-with-pydantic.md`
- **コミットリスト:**
  - `chore: remove GITHUB_WEBHOOK_SECRET remnants`

## 3. 検証結果 (Verification)
- **実行したテスト:** なし (ドキュメントとテストデータの削除のため)
- **動作確認:** プロジェクト全体を "GITHUB_WEBHOOK_SECRET" で検索し、残存箇所がないことを確認しました。

## 4. 影響範囲と今後の課題 (Impact & Next Steps)
### 影響範囲と仕様の変更点
- `GITHUB_WEBHOOK_SECRET`に関する記述が削除されたため、新規開発者が混乱する可能性がなくなりました。

### 残課題と次のアクション
- なし