### PR TITLE
fix: docker-compose.ymlに環境変数を復元

### DIFF
--- a/.build/context/docker-compose.yml
+++ b/.build/context/docker-compose.yml
@@ -17,6 +17,9 @@ services:
     environment:
       - AGENT_NAME=${AGENT_NAME:-your_agent_name}
       - MESSAGE_DIR=${MESSAGE_DIR:-/app/messages}
+      - GITHUB_REPOSITORY=${GITHUB_REPOSITORY:-my_account/my_repository}
+      - BROKER_HOST=${BROKER_HOST:-github_broker}
+      - BROKER_PORT=${BROKER_PORT:-8000}
       - GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT:-your_gcp_project}
       - GOOGLE_CLOUD_LOCATION=${GOOGLE_CLOUD_LOCATION:-us-central1}
     depends_on:
@@ -46,6 +49,7 @@ services:
       - "${BROKER_PORT:-8000}:${BROKER_PORT:-8000}"
     environment:
       - BROKER_PORT=${BROKER_PORT:-8000}
+      - GITHUB_REPOSITORY=${GITHUB_REPOSITORY:-my_account/my_repository}
       - REDIS_HOST=redis
       - REDIS_PORT=6379
     depends_on:

--- a/.build/context/docker-compose.yml
+++ b/.build/context/docker-compose.yml
@@ -10,17 +10,13 @@ services:
       - gemini_config:${ROOT:-/root}/.gemini
     secrets:
       - gcp_access_key
+      - github_token
     working_dir: ${CONTAINER_VOLUME:-/app}
     ports:
       - "${AGENT_PORT:-8080}:${AGENT_PORT:-8080}"
     environment:
       - AGENT_NAME=${AGENT_NAME:-your_agent_name}
       - MESSAGE_DIR=${MESSAGE_DIR:-/app/messages}
-      - GITHUB_REPOSITORY=${GITHUB_REPOSITORY:-my_account/my_repository}
-      - BROKER_HOST=${BROKER_HOST:-github_broker}
-      - BROKER_PORT=${BROKER_PORT:-8000}
-      - GITHUB_TOKEN=${GITHUB_TOKEN:-my_github_token}
-      - GEMINI_API_KEY=${GEMINI_API_KEY:-my_gemini_api_key}
       - GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT:-your_gcp_project}
       - GOOGLE_CLOUD_LOCATION=${GOOGLE_CLOUD_LOCATION:-us-central1}
     depends_on:
@@ -43,13 +39,13 @@ services:
     volumes:
       - ./${BROKER_HOST}:${CONTAINER_VOLUME:-/app}
       - ./messages:${MESSAGE_DIR:-/app/messages}
+    secrets:
+      - github_token
     working_dir: ${CONTAINER_VOLUME:-/app}
     ports:
       - "${BROKER_PORT:-8000}:${BROKER_PORT:-8000}"
     environment:
       - BROKER_PORT=${BROKER_PORT:-8000}
-      - GITHUB_REPOSITORY=${GITHUB_REPOSITORY:-my_account/my_repository}
-      - GITHUB_TOKEN=${GITHUB_TOKEN:-my_github_token}
       - REDIS_HOST=redis
       - REDIS_PORT=6379
     depends_on:
@@ -81,3 +77,5 @@ volumes:
 secrets:
   gcp_access_key:
     file: ./${GCP_ACCESS_KEY}
+  github_token:
+    file: ./github_token.txt

--- a/docs/guides/local-secrets-management.md
+++ b/docs/guides/local-secrets-management.md
@@ -52,3 +52,16 @@
 -   `GEMINI_API_KEY`: `docker-compose.override.yml` を作成し、`agent` サービスの `environment` セクションで設定します。これはオプションです。
 
 これらのファイルを Git にコミットしないように注意し、ローカル環境でのみ使用してください。
+
+---
+### `.gitignore` の設定
+
+ローカル環境用のシークレットファイルが誤ってリポジトリにコミットされるのを防ぐため、プロジェクトの `.gitignore` ファイルに以下の行を追加してください。
+
+```
+# Local secrets and overrides
+github_token.txt
+docker-compose.override.yml
+```
+
+これにより、設定ミスによる機密情報の漏洩リスクをさらに低減できます。

--- a/docs/guides/local-secrets-management.md
+++ b/docs/guides/local-secrets-management.md
@@ -1,0 +1,54 @@
+# ローカル環境でのシークレット管理
+
+このドキュメントでは、開発環境で `GITHUB_TOKEN` および `GEMINI_API_KEY` を安全に管理し、`docker-compose` で利用するための手順を説明します。
+
+## 必須: GITHUB_TOKEN の設定
+
+`GITHUB_TOKEN` は、GitHub API との連携に必須のトークンです。これを Docker Secrets として安全に管理します。
+
+1.  **`github_token.txt` ファイルの作成:**
+    プロジェクトのルートディレクトリに `github_token.txt` という名前のファイルを作成し、その中にあなたの GitHub Personal Access Token (PAT) を記述します。
+
+    ```bash
+    echo "YOUR_GITHUB_PERSONAL_ACCESS_TOKEN" > github_token.txt
+    ```
+
+    **重要:** このファイルは `.gitignore` に追加され、Git リポジトリにコミットされないようにしてください。
+
+2.  **`docker-compose.yml` での利用:**
+    `docker-compose.yml` は、この `github_token.txt` を Docker Secret として自動的に読み込み、`agent` および `github_broker` サービスに安全に渡します。
+
+## オプション: GEMINI_API_KEY の設定
+
+`GEMINI_API_KEY` は、Gemini API を利用する場合にのみ必要です。すべての開発者が利用するわけではないため、`docker-compose.override.yml` を使用してオプションで設定します。
+
+1.  **`docker-compose.override.yml` ファイルの作成:**
+    プロジェクトのルートディレクトリに `docker-compose.override.yml` という名前のファイルを作成します。このファイルは `docker-compose.yml` の設定を上書き・拡張するために使用されます。
+
+    ```yaml
+    # docker-compose.override.yml
+    version: '3.8'
+
+    services:
+      agent:
+        environment:
+          - GEMINI_API_KEY=YOUR_GEMINI_API_KEY
+    ```
+
+    `YOUR_GEMINI_API_KEY` の部分をあなたの Gemini API キーに置き換えてください。
+
+    **重要:** このファイルも `.gitignore` に追加され、Git リポジトリにコミットされないようにしてください。
+
+2.  **`docker-compose.override.yml` の利用:**
+    `docker-compose` コマンドを実行する際、`docker-compose.override.yml` が存在すれば自動的に読み込まれます。これにより、`agent` サービスに `GEMINI_API_KEY` が環境変数として渡されます。
+
+    ```bash
+    docker-compose up -d
+    ```
+
+### まとめ
+
+-   `GITHUB_TOKEN`: `github_token.txt` ファイルを作成し、その中にトークンを記述します。これは必須です。
+-   `GEMINI_API_KEY`: `docker-compose.override.yml` を作成し、`agent` サービスの `environment` セクションで設定します。これはオプションです。
+
+これらのファイルを Git にコミットしないように注意し、ローカル環境でのみ使用してください。


### PR DESCRIPTION
このPull Requestは、#1002 に寄せられたレビューコメントを反映するものです。

`.build/context/docker-compose.yml`に対して以下の修正を行いました。

- `agent`サービスに、動作に必要となる可能性がある以下の環境変数を復元しました。
  - `GITHUB_REPOSITORY`
  - `BROKER_HOST`
  - `BROKER_PORT`
- `github_broker`サービスに、必須設定項目である`GITHUB_REPOSITORY`環境変数を復元しました。

これにより、各サービスが正しく設定され、環境変数の欠落による実行時エラーを未然に防ぎます。