### PR TITLE
docs: Update TaskService logic in request-task-sequence.md (TASK #1016)

### DIFF
--- a/docs/architecture/request-task-sequence.md
+++ b/docs/architecture/request-task-sequence.md
@@ -23,30 +23,41 @@ sequenceDiagram
     alt 前タスク(in-progress)がRedisに記録されている or GitHub上で見つかる
         Note over TaskService: prev_issue_id は agent_id に以前割り当てられていた Issue の ID
         TaskService->>+GitHubClient: update_issue(prev_issue_id, remove_labels=["in-progress", "{agent_id}"], add_labels=["needs-review"])
+        TaskService->>+RedisClient: set_value(needs_review_timestamp:{prev_issue_id}, current_timestamp)
         GitHubClient-->>-TaskService: OK
+        RedisClient-->>-TaskService: OK
     end
 
     TaskService->>TaskService: 1. 役割に合うタスクを候補化 (フィルタリング)
-    
+    Note over TaskService: 優先度、needs-reviewラベル、待機時間を考慮
+
     alt 割り当て可能なタスク候補あり
-        Note over TaskService: 優先順位に基づき最初の候補を選択 (selected_issue_id)
-        TaskService->>+RedisClient: acquire_lock(issue_lock_{selected_issue_id}, "locked", timeout=600)
-        RedisClient-->>-TaskService: Lock Acquired / Failed
+        loop タスク候補の選定とロック取得
+            TaskService->>TaskService: 候補Issueを優先度順にソート
+            Note over TaskService: 優先度: needs-review (待機時間経過) > 通常タスク
+            Note over TaskService: 各カテゴリ内で作成日時の古い順
 
-        alt ロック取得成功 & 前提条件(成果物セクション)満たす
-            TaskService->>+GitHubClient: create_branch(branch_name, base_branch)
-            GitHubClient-->>-TaskService: OK
+            TaskService->>+RedisClient: acquire_lock(issue_lock_{selected_issue_id}, "locked", timeout=600)
+            RedisClient-->>-TaskService: Lock Acquired / Failed
 
-            TaskService->>+GitHubClient: update_issue(selected_issue_id, add_labels=["in-progress", "{agent_id}"])
-            GitHubClient-->>-TaskService: OK
+            alt ロック取得成功 & 前提条件(成果物セクション)満たす
+                TaskService->>+GitHubClient: create_branch(branch_name, base_branch)
+                GitHubClient-->>-TaskService: OK
 
-            TaskService->>+RedisClient: set_value(agent_current_task:{agent_id}, selected_issue_id)
-            RedisClient-->>-TaskService: OK
+                TaskService->>+GitHubClient: update_issue(selected_issue_id, add_labels=["in-progress", "{agent_id}"], remove_labels=["needs-review"])
+                GitHubClient-->>-TaskService: OK
+                TaskService->>+RedisClient: delete_value(needs_review_timestamp:{selected_issue_id})
+                RedisClient-->>-TaskService: OK
 
-            TaskService-->>-ApiServer: TaskResponse (issue_id, url, title, body, labels, branch_name, prompt)
-            ApiServer-->>-Worker: 200 OK (TaskResponse)
-        else ロック取得失敗 または 前提条件満たさない
-            TaskService->>TaskService: 次の候補Issueをチェック / リトライ
+                TaskService->>+RedisClient: set_value(agent_current_task:{agent_id}, selected_issue_id)
+                RedisClient-->>-TaskService: OK
+
+                TaskService-->>-ApiServer: TaskResponse (issue_id, url, title, body, labels, branch_name, prompt)
+                ApiServer-->>-Worker: 200 OK (TaskResponse)
+                break
+            else ロック取得失敗 または 前提条件満たさない
+                TaskService->>TaskService: 次の候補Issueをチェック / リトライ
+            end
         end
     else 割り当て可能なタスク候補なし
         TaskService-->>-ApiServer: None
@@ -69,15 +80,18 @@ sequenceDiagram
 1.  **タスク要求:** ワーカーエージェントは、自身の`agent_id`と`agent_role`を添えてAPIサーバーの`/request-task`エンドポイントにPOSTリクエストを送信します。
 2.  **TaskService呼び出し:** APIサーバーはリクエストを受け取り、`TaskService`の`request_task`メソッドを呼び出します。
 3.  **Issueキャッシュの取得:** `TaskService`は、まず`RedisClient`を介して、バックグラウンドで定期的にキャッシュされているオープンなIssueのリストを取得します。
-4.  **前タスクの完了処理:** エージェントに以前割り当てられていた`in-progress`状態のタスク(`prev_issue_id`)がないか確認します。もし存在すれば、そのIssueのラベルを`needs-review`に更新し、`in-progress`と`[agent_id]`ラベルを削除します。
+4.  **前タスクの完了処理:** エージェントに以前割り当てられていた`in-progress`状態のタスク(`prev_issue_id`)がないか確認します。もし存在すれば、そのIssueのラベルを`needs-review`に更新し、`in-progress`と`[agent_id]`ラベルを削除します。**この際、`needs-review`ラベルが付与された時刻を`RedisClient`に`needs_review_timestamp:{prev_issue_id}`として記録します。これは、後続のタスク選定ロジックで「レビューコメントを待つための時間」を判断するために使用されます。**
 5.  **タスク候補の選定:**
-    *   **候補のフィルタリング:** Redisから取得したIssueリストから、エージェントの`agent_role`に合致し、かつ`in-progress`や`needs-review`ラベルが付いていないタスクをフィルタリングします。
-    *   **最適Issue選択:** フィルタリングされた候補Issueが存在する場合、`TaskService`は優先順位（例: 作成日が最も古い）に基づき、最初の候補を最適なIssueとして選択します (`selected_issue_id`)。
+    *   **候補のフィルタリング:** Redisから取得したIssueリストから、エージェントの`agent_role`に合致するタスクをフィルタリングします。
+    *   **優先度付けと最適Issue選択:** フィルタリングされた候補Issueは、以下の優先順位に基づいてソートされ、最適なIssueが選択されます。
+        1.  **`needs-review`かつレビューコメント待機時間経過済みのタスク:** `needs_review_timestamp`に記録された時刻から一定時間（例: 24時間）が経過した`needs-review`ラベル付きのタスクが最優先されます。これにより、レビュー待ちのタスクが放置されることなく、適切なタイミングで再処理の対象となります。
+        2.  **通常のオープンタスク:** 上記以外の、`in-progress`や`needs-review`ラベルが付いていない通常のオープンタスク。
+        各カテゴリ内では、Issueの作成日時が古いものから優先的に選択されます。
     *   **ロック取得:** 選択されたIssue (`selected_issue_id`) に対して、`RedisClient`を使用して分散ロックの取得を試みます。これにより、複数のエージェントが同時に同じIssueを処理することを防ぎます。
     *   **前提条件チェック:** ロック取得に成功した場合、Issueの本文に「成果物」セクションが正しく定義されているかなどの前提条件をチェックします。
 6.  **タスク割り当てとレスポンス:**
     *   **ブランチ作成:** 新しいタスクとして選択されたIssueに対応するブランチを`GitHubClient`を介して作成します。
-    *   **タスク割り当て:** 新しいタスクのIssueに`in-progress`と`[agent_id]`ラベルを付与します。
+    *   **タスク割り当て:** 新しいタスクのIssueに`in-progress`と`[agent_id]`ラベルを付与し、もし`needs-review`ラベルが付いていた場合はそれを削除します。**また、`needs_review_timestamp:{selected_issue_id}`に記録された値も削除します。**
     *   **現在タスクの記録:** `RedisClient`に、エージェントが現在どのIssueに取り組んでいるか (`agent_current_task:{agent_id}`) を記録します。
     *   **レスポンス:** 割り当てられたタスク情報（Issue ID, URL, タイトル, 本文, ラベル, ブランチ名, プロンプト）を`TaskResponse`としてワーカーエージェントに返します。
 7.  **タスクなし:** 割り当て可能なタスクが見つからなかった場合、APIサーバーは`204 No Content`を返します。


### PR DESCRIPTION
Closes #1016

This PR updates the `docs/architecture/request-task-sequence.md` to reflect the new `TaskService` logic. The changes include:
- Updated sequence diagram to incorporate priority, `needs-review` label, and waiting time for review comments.
- Detailed explanation of the new task selection process, including how `needs-review` tasks are handled after a certain waiting period.