### PR TITLE
feat: Issue #1026 - Add get_pull_request_info_from_issue method to GitHubClient

### DIFF
--- a/github_broker/infrastructure/github_client.py
+++ b/github_broker/infrastructure/github_client.py
@@ -145,25 +145,26 @@ class GitHubClient:
             )
             raise
 
-    def get_pull_request_info_from_issue(self, issue_number: int):
+    def get_pull_request_info_from_issue(self, issue_number: int) -> dict | None:
         """
         Issue番号から、そのIssueに紐づくPull Requestの情報を取得します。
         PRが存在しない場合はNoneを返します。
         """
         try:
-            # Issue番号が本文に含まれるPRを検索
-            query = f"repo:{self._repo_name} is:pr type:pr in:body {issue_number}"
+            # Issue番号が本文に含まれるオープンなPRを検索
+            query = f"repo:{self._repo_name} is:pr is:open in:body {issue_number}"
             logging.info(f"クエリ: {query} でPRを検索中")
             pull_requests = self._client.search_issues(query=query)
 
             if pull_requests.totalCount > 0:
                 # 最初のPRを返す（通常、Issueに紐づくPRは1つと想定）
                 pr = pull_requests[0]
-                logging.info(f"Issue #{issue_number} に紐づくPR #{pr.number} が見つかりました。")
+                logging.info(
+                    f"Issue #{issue_number} に紐づくPR #{pr.number} が見つかりました。"
+                )
                 return pr.raw_data
-            else:
-                logging.info(f"Issue #{issue_number} に紐づくPRは見つかりませんでした。")
-                return None
+            logging.info(f"Issue #{issue_number} に紐づくPRは見つかりませんでした。")
+            return None
         except GithubException as e:
             logging.error(
                 f"リポジトリ {self._repo_name} のIssue #{issue_number} に紐づくPRの検索中にエラーが発生しました: {e}"

--- a/github_broker/infrastructure/github_client.py
+++ b/github_broker/infrastructure/github_client.py
@@ -145,6 +145,31 @@ class GitHubClient:
             )
             raise
 
+    def get_pull_request_info_from_issue(self, issue_number: int):
+        """
+        Issue番号から、そのIssueに紐づくPull Requestの情報を取得します。
+        PRが存在しない場合はNoneを返します。
+        """
+        try:
+            # Issue番号が本文に含まれるPRを検索
+            query = f"repo:{self._repo_name} is:pr type:pr in:body {issue_number}"
+            logging.info(f"クエリ: {query} でPRを検索中")
+            pull_requests = self._client.search_issues(query=query)
+
+            if pull_requests.totalCount > 0:
+                # 最初のPRを返す（通常、Issueに紐づくPRは1つと想定）
+                pr = pull_requests[0]
+                logging.info(f"Issue #{issue_number} に紐づくPR #{pr.number} が見つかりました。")
+                return pr.raw_data
+            else:
+                logging.info(f"Issue #{issue_number} に紐づくPRは見つかりませんでした。")
+                return None
+        except GithubException as e:
+            logging.error(
+                f"リポジトリ {self._repo_name} のIssue #{issue_number} に紐づくPRの検索中にエラーが発生しました: {e}"
+            )
+            raise
+
     def get_issue_by_number(self, issue_number: int):
         """
         特定のIssue番号に対応するIssueの生データを取得します。

--- a/tests/infrastructure/test_github_client.py
+++ b/tests/infrastructure/test_github_client.py
@@ -539,7 +539,11 @@ def test_get_pull_request_info_from_issue_found(mock_github):
     """get_pull_request_info_from_issueがPRにマッチしたときに正しいPR情報を返すことをテストします。"""
     # Arrange
     mock_pr = MagicMock()
-    mock_pr.raw_data = {"number": 1, "html_url": "https://github.com/test/repo/pull/1", "state": "open"}
+    mock_pr.raw_data = {
+        "number": 1,
+        "html_url": "https://github.com/test/repo/pull/1",
+        "state": "open",
+    }
 
     mock_search_results = MagicMock()
     mock_search_results.totalCount = 1
@@ -562,27 +566,7 @@ def test_get_pull_request_info_from_issue_found(mock_github):
     assert pr_info["html_url"] == "https://github.com/test/repo/pull/1"
     assert pr_info["state"] == "open"
     mock_github_instance.search_issues.assert_called_once_with(
-        query=f"repo:{repo_name} is:pr type:pr in:body {issue_number}"
-    )
-
-    mock_github_instance = MagicMock()
-    mock_github_instance.search_issues.return_value = mock_search_results
-    mock_github.return_value = mock_github_instance
-
-    repo_name = "test/repo"
-    client = GitHubClient(repo_name, "fake_token")
-    issue_number = 123
-
-    # Act
-    pr_info = client.get_pull_request_info_from_issue(issue_number)
-
-    # Assert
-    assert pr_info is not None
-    assert pr_info["number"] == 1
-    assert pr_info["html_url"] == "https://github.com/test/repo/pull/1"
-    assert pr_info["state"] == "open"
-    mock_github_instance.search_issues.assert_called_once_with(
-        query=f"repo:{repo_name} is:pr type:pr in:body {issue_number}"
+        query=f"repo:{repo_name} is:pr is:open in:body {issue_number}"
     )
 
 
@@ -593,7 +577,6 @@ def test_get_pull_request_info_from_issue_not_found(mock_github):
     # Arrange
     mock_search_results = MagicMock()
     mock_search_results.totalCount = 0
-    mock_search_results.__iter__.return_value = []
 
     mock_github_instance = MagicMock()
     mock_github_instance.search_issues.return_value = mock_search_results
@@ -609,7 +592,7 @@ def test_get_pull_request_info_from_issue_not_found(mock_github):
     # Assert
     assert pr_info is None
     mock_github_instance.search_issues.assert_called_once_with(
-        query=f"repo:{repo_name} is:pr type:pr in:body {issue_number}"
+        query=f"repo:{repo_name} is:pr is:open in:body {issue_number}"
     )
 
 

--- a/tests/infrastructure/test_github_client.py
+++ b/tests/infrastructure/test_github_client.py
@@ -531,3 +531,103 @@ def test_update_issue_remove_label_raises_exception(mock_github):
     # Act & Assert
     with pytest.raises(GithubException):
         client.update_issue(issue_id, remove_labels=remove_labels)
+
+
+@pytest.mark.unit
+@patch("github_broker.infrastructure.github_client.Github")
+def test_get_pull_request_info_from_issue_found(mock_github):
+    """get_pull_request_info_from_issueがPRにマッチしたときに正しいPR情報を返すことをテストします。"""
+    # Arrange
+    mock_pr = MagicMock()
+    mock_pr.raw_data = {"number": 1, "html_url": "https://github.com/test/repo/pull/1", "state": "open"}
+
+    mock_search_results = MagicMock()
+    mock_search_results.totalCount = 1
+    mock_search_results.__getitem__.return_value = mock_pr
+
+    mock_github_instance = MagicMock()
+    mock_github_instance.search_issues.return_value = mock_search_results
+    mock_github.return_value = mock_github_instance
+
+    repo_name = "test/repo"
+    client = GitHubClient(repo_name, "fake_token")
+    issue_number = 123
+
+    # Act
+    pr_info = client.get_pull_request_info_from_issue(issue_number)
+
+    # Assert
+    assert pr_info is not None
+    assert pr_info["number"] == 1
+    assert pr_info["html_url"] == "https://github.com/test/repo/pull/1"
+    assert pr_info["state"] == "open"
+    mock_github_instance.search_issues.assert_called_once_with(
+        query=f"repo:{repo_name} is:pr type:pr in:body {issue_number}"
+    )
+
+    mock_github_instance = MagicMock()
+    mock_github_instance.search_issues.return_value = mock_search_results
+    mock_github.return_value = mock_github_instance
+
+    repo_name = "test/repo"
+    client = GitHubClient(repo_name, "fake_token")
+    issue_number = 123
+
+    # Act
+    pr_info = client.get_pull_request_info_from_issue(issue_number)
+
+    # Assert
+    assert pr_info is not None
+    assert pr_info["number"] == 1
+    assert pr_info["html_url"] == "https://github.com/test/repo/pull/1"
+    assert pr_info["state"] == "open"
+    mock_github_instance.search_issues.assert_called_once_with(
+        query=f"repo:{repo_name} is:pr type:pr in:body {issue_number}"
+    )
+
+
+@pytest.mark.unit
+@patch("github_broker.infrastructure.github_client.Github")
+def test_get_pull_request_info_from_issue_not_found(mock_github):
+    """get_pull_request_info_from_issueがPRにマッチしない場合にNoneを返すことをテストします。"""
+    # Arrange
+    mock_search_results = MagicMock()
+    mock_search_results.totalCount = 0
+    mock_search_results.__iter__.return_value = []
+
+    mock_github_instance = MagicMock()
+    mock_github_instance.search_issues.return_value = mock_search_results
+    mock_github.return_value = mock_github_instance
+
+    repo_name = "test/repo"
+    client = GitHubClient(repo_name, "fake_token")
+    issue_number = 123
+
+    # Act
+    pr_info = client.get_pull_request_info_from_issue(issue_number)
+
+    # Assert
+    assert pr_info is None
+    mock_github_instance.search_issues.assert_called_once_with(
+        query=f"repo:{repo_name} is:pr type:pr in:body {issue_number}"
+    )
+
+
+@pytest.mark.unit
+@patch("github_broker.infrastructure.github_client.Github")
+def test_get_pull_request_info_from_issue_raises_exception(mock_github):
+    """get_pull_request_info_from_issueがAPI呼び出し失敗時に例外を送出することをテストします。"""
+    # Arrange
+    mock_github_instance = MagicMock()
+    mock_github_instance.search_issues.side_effect = GithubException(
+        status=500, data={}, headers=None
+    )
+    mock_github.return_value = mock_github_instance
+
+    repo_name = "test/repo"
+    client = GitHubClient(repo_name, "fake_token")
+    issue_number = 123
+
+    # Act & Assert
+    with pytest.raises(GithubException):
+        client.get_pull_request_info_from_issue(issue_number)


### PR DESCRIPTION
## 1. 目的とゴール (Purpose & Goal)
- **解決したいIssue:** #1026
- **この作業の目的:** Issue番号から、そのIssueに紐づくPull Requestの情報を取得する機能を`GitHubClient`に実装する。
- **ゴール(完了条件):** `GitHubClient`に、Issue番号を引数として、関連するPRのURLやステータスなどを含む情報を返す新しいメソッドが実装されていること。PRが存在しない場合は`None`を返すなど、適切なエラーハンドリングが行われていること。

## 2. 実施内容 (Implementation Details)
### 設計判断と決定事項
- `GitHubClient`に`get_pull_request_info_from_issue`メソッドを追加しました。
- このメソッドは、GitHub APIの`search_issues`を使用して、Issue番号が本文に含まれるPRを検索します。
- PRが存在しない場合は`None`を返します。

### 具体的な作業ログと成果物
- **作業ブランチ:** `feature/1026-get-pr-info-from-issue`
- **主要な変更ファイル:**
  - `github_broker/infrastructure/github_client.py` (新メソッドの追加)
  - `tests/infrastructure/test_github_client.py` (新メソッドのテストケース追加)
- **コミットリスト:**
  - `feat: Add get_pull_request_info_from_issue method to GitHubClient`

## 3. 検証結果 (Verification)
- **実行したテスト:** `pytest /app/tests/infrastructure/test_github_client.py`
- **テスト結果:** 全てのテストがパスしました。

## 4. 影響範囲と今後の課題 (Impact & Next Steps)
### 影響範囲と仕様の変更点
- `GitHubClient`に新しいメソッドが追加されました。既存の機能への影響はありません。

### 残課題と次のアクション
- なし